### PR TITLE
Replace deprecated contains usage with includes

### DIFF
--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -162,7 +162,7 @@ export function Tags({
             }}
             key={i}
             className={`tag ${c('item-tag')} ${
-              searchQuery && tag.toLocaleLowerCase().contains(searchQuery) ? 'is-search-match' : ''
+              searchQuery && tag.toLocaleLowerCase().includes(searchQuery) ? 'is-search-match' : ''
             }`}
             style={
               tagColor && {

--- a/src/components/Item/MetadataTable.tsx
+++ b/src/components/Item/MetadataTable.tsx
@@ -155,7 +155,7 @@ export function MetadataValue({ data, dateLabel, searchQuery }: MetadataValuePro
     const link = getLinkFromObj(v, view);
     const date = getDate(v);
     const str = anyToString(v, stateManager);
-    const isMatch = searchQuery && str.toLocaleLowerCase().contains(searchQuery);
+    const isMatch = searchQuery && str.toLocaleLowerCase().includes(searchQuery);
 
     let content: ComponentChild;
     if (link || data.containsMarkdown) {
@@ -236,7 +236,7 @@ export const MetadataTable = memo(function MetadataTable({
           const data = metadata[k];
           if (!data) return null;
 
-          const isSearchMatch = (data.label || k).toLocaleLowerCase().contains(searchQuery);
+          const isSearchMatch = (data.label || k).toLocaleLowerCase().includes(searchQuery);
           return (
             <tr key={k} className={c('meta-row')}>
               {!data.shouldHideLabel && (

--- a/src/dnd/util/hitbox.ts
+++ b/src/dnd/util/hitbox.ts
@@ -284,7 +284,7 @@ export function getBestIntersect(
     const entityHitbox = entity.getHitbox();
     const entityCenter = centerOfRectangle(entityHitbox);
 
-    if (isDropArea && !isDropArea.contains(dragEntity.getData().type)) {
+    if (isDropArea && !isDropArea.includes(dragEntity.getData().type)) {
       return distanceBetween(dragCenter, entityCenter);
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,7 +49,7 @@ export function hasFrontmatterKeyRaw(data: string) {
     return false;
   }
 
-  if (!match[1].contains(frontmatterKey)) {
+  if (!match[1].includes(frontmatterKey)) {
     return false;
   }
 

--- a/src/helpers/renderMarkdown.ts
+++ b/src/helpers/renderMarkdown.ts
@@ -92,7 +92,7 @@ export function bindMarkdownEvents(view: KanbanView) {
 
     evt.preventDefault();
 
-    if (!link.href || link.href.contains(' ')) return;
+    if (!link.href || link.href.includes(' ')) return;
     try {
       new URL(link.href);
     } catch (e) {


### PR DESCRIPTION
## Summary
- replace deprecated String.prototype.contains usages with includes in helpers, metadata rendering, and drag-and-drop utilities
- ensure search filtering and tag highlighting keep existing lowercase handling while using standard methods
- switch drop area guard to use Array.prototype.includes for sort filtering

## Testing
- yarn typecheck *(fails: requires dependencies that cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d94a59d81c832a818eafd264856b84