### PR TITLE
Fix state receiver cleanup in useState

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -184,10 +184,11 @@ export class StateManager {
     const [state, setState] = useState(this.state);
 
     useEffect(() => {
-      this.stateReceivers.push((state) => setState(state));
+      const receiver = (state: Board) => setState(state);
+      this.stateReceivers.push(receiver);
       setState(this.state);
       return () => {
-        this.stateReceivers.remove(setState);
+        this.stateReceivers.remove(receiver);
       };
     }, []);
 


### PR DESCRIPTION
## Summary
- store the state receiver callback for reuse in cleanup
- ensure the exact same receiver reference is removed during effect cleanup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94a347414832aad3b4588f30a366e