### PR TITLE
Fix note template integration with latest Obsidian API

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -7,7 +7,12 @@ import { moveEntity } from 'src/dnd/util/data';
 import { t } from 'src/lang/helpers';
 
 import { BoardModifiers } from '../../helpers/boardModifiers';
-import { applyTemplate, escapeRegExpStr, generateInstanceId } from '../helpers';
+import {
+  applyTemplate,
+  createMarkdownFileWithFallback,
+  escapeRegExpStr,
+  generateInstanceId,
+} from '../helpers';
 import { EditState, Item } from '../types';
 import {
   constructDatePicker,
@@ -72,7 +77,8 @@ export function useItemMenu({
                 ? (stateManager.app.vault.getAbstractFileByPath(newNoteFolder as string) as TFolder)
                 : stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
 
-              const newFile = (await (stateManager.app.fileManager as any).createNewMarkdownFile(
+              const newFile = (await createMarkdownFileWithFallback(
+                stateManager.app,
                 targetFolder,
                 sanitizedTitle
               )) as TFile;


### PR DESCRIPTION
## Summary
- update the note template workflow to wait for an active markdown view and to cooperate with whichever template plugin (Templater or the core Templates plugin) is currently available
- add resilient detection helpers that fall back to directly writing template content when plugin APIs are unavailable
- create a markdown file helper that supports both modern and legacy Obsidian file manager methods and update the card menu to use it

## Testing
- not run (project setup requires dependencies that are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d94a1cea30832ab2ae9535e584ac47